### PR TITLE
Added between, line and any_char

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -11,4 +11,4 @@ gleam = ">= 0.32.0"
 gleam_stdlib = "~> 0.36" # 0.36 <= version < 0.37
 
 [dev-dependencies]
-gleeunit = "~> 0.10"
+gleeunit = ">= 0.10.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,9 +3,9 @@
 
 packages = [
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
 gleam_stdlib = { version = "~> 0.36" }
-gleeunit = { version = "~> 0.10" }
+gleeunit = { version = ">= 0.10.0" }

--- a/src/party.gleam
+++ b/src/party.gleam
@@ -77,17 +77,7 @@ pub fn satisfy(when pred: fn(String) -> Bool) -> Parser(String, e) {
 
 /// Parse a single character.
 pub fn any_char() -> Parser(String, e) {
-  Parser(fn(source, pos) {
-    let assert Position(row, col) = pos
-    case source {
-      [h, ..t] ->
-        case h {
-          "\n" -> Ok(#(h, t, Position(row + 1, 0)))
-          _ -> Ok(#(h, t, Position(row, col + 1)))
-        }
-      [] -> Error(Unexpected(pos, "EOF"))
-    }
-  })
+  satisfy(fn(_) { True })
 }
 
 /// Parse a lowercase letter.
@@ -138,9 +128,16 @@ pub fn between(
   return(x)
 }
 
-/// Parse a line of characters as a String. The new line at the end is discarded
-pub fn line() -> Parser(String, e) {
+/// Parse the rest of a line and return the array of parsed characters.
+/// The newline character at the end is discarded.
+pub fn line() -> Parser(List(String), e) {
   until(any_char(), char("\n"))
+}
+
+/// Parse the rest of a line and return the parsed characters as a String.
+/// The newline character at the end is discarded.
+pub fn line_concat() -> Parser(String, e) {
+  line()
   |> map(string.concat)
 }
 

--- a/src/party.gleam
+++ b/src/party.gleam
@@ -138,6 +138,7 @@ pub fn between(
   return(x)
 }
 
+/// Parse a line of characters as a String. The new line at the end is discarded
 pub fn line() -> Parser(String, e) {
   until(any_char(), char("\n"))
   |> map(string.concat)

--- a/test/party_test.gleam
+++ b/test/party_test.gleam
@@ -45,6 +45,43 @@ pub fn satisfy_test() {
   |> should.equal(Error(party.Unexpected(party.Position(1, 1), "a")))
 }
 
+pub fn any_char_test() {
+  party.go(party.any_char(), "a")
+  |> should.equal(Ok("a"))
+  party.go(party.any_char(), "")
+  |> should.equal(Error(party.Unexpected(party.Position(1, 1), "EOF")))
+}
+
+pub fn between_test() {
+  party.go(
+    party.between(party.char("{"), party.char("a"), party.char("}")),
+    "{a}",
+  )
+  |> should.equal(Ok("a"))
+  party.go(
+    party.between(party.char("{"), party.char("a"), party.char("}")),
+    "(a}",
+  )
+  |> should.equal(Error(party.Unexpected(party.Position(1, 1), "(")))
+  party.go(
+    party.between(party.char("{"), party.char("a"), party.char("}")),
+    "{b}",
+  )
+  |> should.equal(Error(party.Unexpected(party.Position(1, 2), "b")))
+  party.go(
+    party.between(party.char("{"), party.char("a"), party.char("}")),
+    "{a)",
+  )
+  |> should.equal(Error(party.Unexpected(party.Position(1, 3), ")")))
+}
+
+pub fn line_test() {
+  party.go(party.line(), "abcdefg hij klmnop \n")
+  |> should.equal(Ok("abcdefg hij klmnop "))
+  party.go(party.line(), "abcdefg hij klmnop ")
+  |> should.equal(Error(party.Unexpected(party.Position(1, 20), "EOF")))
+}
+
 pub fn lowercase_letter_test() {
   party.go(party.lowercase_letter(), "a")
   |> should.equal(Ok("a"))

--- a/test/party_test.gleam
+++ b/test/party_test.gleam
@@ -76,10 +76,17 @@ pub fn between_test() {
 }
 
 pub fn line_test() {
-  party.go(party.line(), "abcdefg hij klmnop \n")
-  |> should.equal(Ok("abcdefg hij klmnop "))
-  party.go(party.line(), "abcdefg hij klmnop ")
-  |> should.equal(Error(party.Unexpected(party.Position(1, 20), "EOF")))
+  party.go(party.line(), "abcde fgh \n")
+  |> should.equal(Ok(["a", "b", "c", "d", "e", " ", "f", "g", "h", " "]))
+  party.go(party.line(), "abcde fgh ")
+  |> should.equal(Error(party.Unexpected(party.Position(1, 11), "EOF")))
+}
+
+pub fn line_concat_test() {
+  party.go(party.line_concat(), "abcde fgh \n")
+  |> should.equal(Ok("abcde fgh "))
+  party.go(party.line_concat(), "abcde fgh ")
+  |> should.equal(Error(party.Unexpected(party.Position(1, 11), "EOF")))
 }
 
 pub fn lowercase_letter_test() {


### PR DESCRIPTION
Added a few combinators/parsers that I found myself rewriting in every project

Added the corresponding tests (had to update the config for the gleamunit module to compile) and documentation

* `between(open, p, close)` parses `p` between `open` and `close`
* `line()` parses the rest of a line (discarding the `\n` character)
* `any_char()` parses a single character 